### PR TITLE
fixed a bug in the ogg muxer that would throw 'RangeError: Maximum call ...

### DIFF
--- a/dist/speex.js
+++ b/dist/speex.js
@@ -6531,6 +6531,13 @@ Ogg.prototype.mux = function (d, o) {
 		return sum;
 	}
 
+  function pack(uintArray) {
+    var s = "";
+    for(var i=0,l=uintArray.length; i<l; i++)
+      s += String.fromCharCode(uintArray[i]);
+    return s;
+  }
+
 	o=o||{};
 
 	var str = "";
@@ -6555,8 +6562,7 @@ Ogg.prototype.mux = function (d, o) {
 	// data page
 	var data = d[2];
 	var segments = data[1].chunk(100)
-	  , stream = String.fromCharCode.apply(null,
-	  		new Uint8Array(data[0].buffer))
+	  , stream = pack(data[0])
 	  , a = 0
 	  , b = 0
 	  , len = segments.length;


### PR DESCRIPTION
...stack size exceeded' on large files.

The String.fromCharCode.apply method on line 6558, of speex.js in dist throws an error when data[0] is too large.  I added the function pack to stringify the char array and avoid the stack range error. 
